### PR TITLE
feat: Add resolution preset picker to job create form

### DIFF
--- a/manager/frontend/src/app/features/projects/job-create-form.component.resolution.spec.ts
+++ b/manager/frontend/src/app/features/projects/job-create-form.component.resolution.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025 Dryad and Naiad Software LLC
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { JobCreateFormComponent } from './job-create-form.component';
+import { JobService } from '../../core/services/job.service';
+import { TiledJobService } from '../../core/services/tiled-job.service';
+import { AnimationService } from '../../core/services/animation.service';
+
+describe('JobCreateFormComponent — resolution preset coverage', () => {
+  describe('resolution preset submission', () => {
+    let component: JobCreateFormComponent;
+    let mockJobService: jasmine.SpyObj<JobService>;
+    let mockTiledJobService: jasmine.SpyObj<TiledJobService>;
+    let mockAnimationService: jasmine.SpyObj<AnimationService>;
+    let mockDialogRef: jasmine.SpyObj<MatDialogRef<JobCreateFormComponent>>;
+
+    beforeEach(async () => {
+      mockJobService = jasmine.createSpyObj('JobService', ['create']);
+      mockTiledJobService = jasmine.createSpyObj('TiledJobService', ['create']);
+      mockAnimationService = jasmine.createSpyObj('AnimationService', ['create']);
+      mockDialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+      await TestBed.configureTestingModule({
+        imports: [JobCreateFormComponent, NoopAnimationsModule],
+        providers: [
+          { provide: JobService, useValue: mockJobService },
+          { provide: TiledJobService, useValue: mockTiledJobService },
+          { provide: AnimationService, useValue: mockAnimationService },
+          { provide: MatDialogRef, useValue: mockDialogRef },
+          { provide: MAT_DIALOG_DATA, useValue: { projectId: 'proj-uuid', assetId: 42 } },
+        ],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(JobCreateFormComponent);
+      component = fixture.componentInstance;
+      const snackBar = fixture.debugElement.injector.get(MatSnackBar);
+      spyOn(snackBar, 'open');
+      fixture.detectChanges();
+    });
+
+    it('should submit Preset mode with uhd4k preset producing 3840x2160 in payload', () => {
+      component.renderType = 'single';
+      component.form.controls.name.setValue('Preset Render');
+      component.form.controls.resolutionMode.setValue('preset');
+      component.form.controls.resolutionPreset.setValue('uhd4k');
+      mockJobService.create.and.returnValue(of({ name: 'Preset Render' } as any));
+
+      component.onSubmit();
+
+      const callArgs = mockJobService.create.calls.mostRecent().args[0] as any;
+      expect(callArgs.render_settings['render.resolution_x']).toBe(3840);
+      expect(callArgs.render_settings['render.resolution_y']).toBe(2160);
+    });
+
+    it('should submit Custom mode with user-typed 1600/900 producing those values in payload', () => {
+      component.renderType = 'single';
+      component.form.controls.name.setValue('Custom Render');
+      component.form.controls.resolutionMode.setValue('custom');
+      component.form.controls.resolutionX.setValue(1600);
+      component.form.controls.resolutionY.setValue(900);
+      mockJobService.create.and.returnValue(of({ name: 'Custom Render' } as any));
+
+      component.onSubmit();
+
+      const callArgs = mockJobService.create.calls.mostRecent().args[0] as any;
+      expect(callArgs.render_settings['render.resolution_x']).toBe(1600);
+      expect(callArgs.render_settings['render.resolution_y']).toBe(900);
+    });
+  });
+
+  describe('dialog re-open with different prefill (S8)', () => {
+    async function createFixtureWithPrefill(
+      resolutionX: number, resolutionY: number,
+    ): Promise<JobCreateFormComponent> {
+      const localJobService = jasmine.createSpyObj<JobService>('JobService', ['create']);
+      const localTiledJobService = jasmine.createSpyObj<TiledJobService>('TiledJobService', ['create']);
+      const localAnimationService = jasmine.createSpyObj<AnimationService>('AnimationService', ['create']);
+      const localDialogRef = jasmine.createSpyObj<MatDialogRef<JobCreateFormComponent>>(
+        'MatDialogRef', ['close'],
+      );
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [JobCreateFormComponent, NoopAnimationsModule],
+        providers: [
+          { provide: JobService, useValue: localJobService },
+          { provide: TiledJobService, useValue: localTiledJobService },
+          { provide: AnimationService, useValue: localAnimationService },
+          { provide: MatDialogRef, useValue: localDialogRef },
+          {
+            provide: MAT_DIALOG_DATA,
+            useValue: {
+              projectId: 'proj-uuid',
+              assetId: 42,
+              prefill: { renderType: 'single', resolutionX, resolutionY },
+            },
+          },
+        ],
+      }).compileComponents();
+      const localFixture = TestBed.createComponent(JobCreateFormComponent);
+      const localSnackBar = localFixture.debugElement.injector.get(MatSnackBar);
+      spyOn(localSnackBar, 'open');
+      localFixture.detectChanges();
+      return localFixture.componentInstance;
+    }
+
+    it('should detect fhd1080 preset on first open with 1920x1080 prefill', async () => {
+      const c = await createFixtureWithPrefill(1920, 1080);
+      expect(c.form.controls.resolutionMode.value).toBe('preset');
+      expect(c.form.controls.resolutionPreset.value).toBe('fhd1080');
+      expect(c.form.controls.resolutionX.value).toBe(1920);
+      expect(c.form.controls.resolutionY.value).toBe(1080);
+    });
+
+    it('should detect uhd4k preset on second open with 3840x2160 prefill (fresh instance)', async () => {
+      // First open with 1920x1080
+      await createFixtureWithPrefill(1920, 1080);
+      // Second open (fresh fixture) with 3840x2160
+      const c2 = await createFixtureWithPrefill(3840, 2160);
+      expect(c2.form.controls.resolutionMode.value).toBe('preset');
+      expect(c2.form.controls.resolutionPreset.value).toBe('uhd4k');
+      expect(c2.form.controls.resolutionX.value).toBe(3840);
+      expect(c2.form.controls.resolutionY.value).toBe(2160);
+    });
+  });
+});

--- a/manager/frontend/src/app/features/projects/job-create-form.component.ts
+++ b/manager/frontend/src/app/features/projects/job-create-form.component.ts
@@ -22,6 +22,7 @@ import { RENDER_ENGINES, RENDER_DEVICES, TILING_OPTIONS, ANIMATION_TILING_OPTION
 import { buildSingleJobPayload, buildTiledJobPayload, buildAnimationPayload } from './job-create-payload.util';
 import { RenderType, JobCreateDialogData } from './job-create-form.types';
 import { VideoOutputSectionComponent } from './video-output-section.component';
+import { ResolutionInputComponent } from './resolution-input.component';
 
 @Component({
   selector: 'app-job-create-form',
@@ -29,7 +30,7 @@ import { VideoOutputSectionComponent } from './video-output-section.component';
   imports: [
     FormsModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule,
     MatInputModule, MatSelectModule, MatRadioModule,
-    MatButtonModule, MatIconModule, MatSnackBarModule, VideoOutputSectionComponent,
+    MatButtonModule, MatIconModule, MatSnackBarModule, VideoOutputSectionComponent, ResolutionInputComponent,
   ],
   template: `
     <h2 mat-dialog-title>Create Job</h2>
@@ -58,12 +59,8 @@ import { VideoOutputSectionComponent } from './video-output-section.component';
         <div class="form-row">
           <mat-form-field><mat-label>Samples</mat-label>
             <input matInput type="number" formControlName="samples" /></mat-form-field>
-          <mat-form-field><mat-label>Resolution X</mat-label>
-            <input matInput type="number" formControlName="resolutionX" /></mat-form-field>
-          <span class="res-x">x</span>
-          <mat-form-field><mat-label>Resolution Y</mat-label>
-            <input matInput type="number" formControlName="resolutionY" /></mat-form-field>
         </div>
+        <app-resolution-input [parentForm]="form"></app-resolution-input>
         <div class="form-row">
           @if (renderType === 'single') {
             <mat-form-field><mat-label>Frame</mat-label>
@@ -134,7 +131,6 @@ import { VideoOutputSectionComponent } from './video-output-section.component';
     .render-form { display: flex; flex-direction: column; gap: 8px; }
     .form-row { display: flex; gap: 12px; align-items: baseline; flex-wrap: wrap; }
     .form-row mat-form-field { flex: 1; min-width: 120px; }
-    .res-x { padding-top: 12px; }
   `],
 })
 export class JobCreateFormComponent {
@@ -181,6 +177,8 @@ export class JobCreateFormComponent {
     samples: new FormControl(128, [Validators.required, Validators.min(1)]),
     resolutionX: new FormControl(1920, [Validators.required, Validators.min(1)]),
     resolutionY: new FormControl(1080, [Validators.required, Validators.min(1)]),
+    resolutionMode: new FormControl<'preset' | 'custom' | null>('preset', Validators.required),
+    resolutionPreset: new FormControl<string | null>('fhd1080', Validators.required),
     outputFormat: new FormControl('PNG', Validators.required),
     jpegQuality: new FormControl(90, [Validators.required, Validators.min(1), Validators.max(100)]),
     colorDepth: new FormControl('16', Validators.required),

--- a/manager/frontend/src/app/features/projects/resolution-input.component.spec.ts
+++ b/manager/frontend/src/app/features/projects/resolution-input.component.spec.ts
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2025 Dryad and Naiad Software LLC
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { ResolutionInputComponent } from './resolution-input.component';
+
+function createParentForm(overrides?: {
+  resolutionX?: number | null;
+  resolutionY?: number | null;
+}): FormGroup {
+  const xValue = overrides && 'resolutionX' in overrides ? overrides.resolutionX! : 1920;
+  const yValue = overrides && 'resolutionY' in overrides ? overrides.resolutionY! : 1080;
+  const xyValidators = [Validators.required, Validators.min(1)];
+  return new FormGroup({
+    resolutionMode: new FormControl<'preset' | 'custom' | null>('preset', Validators.required),
+    resolutionPreset: new FormControl<string | null>('fhd1080', Validators.required),
+    resolutionX: new FormControl<number | null>(xValue, xyValidators),
+    resolutionY: new FormControl<number | null>(yValue, xyValidators),
+  });
+}
+
+async function setup(parentForm: FormGroup): Promise<{
+  component: ResolutionInputComponent;
+  fixture: ComponentFixture<ResolutionInputComponent>;
+}> {
+  await TestBed.configureTestingModule({
+    imports: [ResolutionInputComponent, NoopAnimationsModule],
+  }).compileComponents();
+  const fixture = TestBed.createComponent(ResolutionInputComponent);
+  const component = fixture.componentInstance;
+  component.parentForm = parentForm;
+  fixture.detectChanges();
+  return { component, fixture };
+}
+
+describe('ResolutionInputComponent', () => {
+  describe('default state', () => {
+    it('should default to preset mode with fhd1080 selected and parent X/Y at 1920/1080', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      expect(parentForm.get('resolutionMode')!.value).toBe('preset');
+      expect(parentForm.get('resolutionPreset')!.value).toBe('fhd1080');
+      expect(parentForm.get('resolutionX')!.value).toBe(1920);
+      expect(parentForm.get('resolutionY')!.value).toBe(1080);
+    });
+
+    it('should disable resolutionX and resolutionY after ngOnInit', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      expect(parentForm.get('resolutionX')!.disabled).toBeTrue();
+      expect(parentForm.get('resolutionY')!.disabled).toBeTrue();
+    });
+  });
+
+  describe('preset selection mechanics', () => {
+    it('should write 3840/2160 into parent X/Y when resolutionPreset changes to uhd4k', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('uhd4k');
+      expect(parentForm.get('resolutionX')!.value).toBe(3840);
+      expect(parentForm.get('resolutionY')!.value).toBe(2160);
+    });
+
+    it('should write 4096/2160 into parent X/Y when resolutionPreset changes to dci4k', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('dci4k');
+      expect(parentForm.get('resolutionX')!.value).toBe(4096);
+      expect(parentForm.get('resolutionY')!.value).toBe(2160);
+    });
+
+    it('should write 1080/1080 into parent X/Y when resolutionPreset changes to sq1080', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('sq1080');
+      expect(parentForm.get('resolutionX')!.value).toBe(1080);
+      expect(parentForm.get('resolutionY')!.value).toBe(1080);
+    });
+  });
+
+  describe('mode toggle', () => {
+    it('should enable resolutionX and resolutionY when mode changes to custom', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionMode')!.setValue('custom');
+      expect(parentForm.get('resolutionX')!.enabled).toBeTrue();
+      expect(parentForm.get('resolutionY')!.enabled).toBeTrue();
+    });
+
+    it('should disable resolutionPreset when mode changes to custom while keeping its value', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('uhd4k');
+      parentForm.get('resolutionMode')!.setValue('custom');
+      expect(parentForm.get('resolutionPreset')!.disabled).toBeTrue();
+      expect(parentForm.get('resolutionPreset')!.value).toBe('uhd4k');
+    });
+
+    it('should re-apply current resolutionPreset x/y when mode changes back to preset, overwriting custom values', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('uhd4k');
+      parentForm.get('resolutionMode')!.setValue('custom');
+      parentForm.get('resolutionX')!.setValue(2000);
+      parentForm.get('resolutionY')!.setValue(1500);
+      parentForm.get('resolutionMode')!.setValue('preset');
+      expect(parentForm.get('resolutionX')!.value).toBe(3840);
+      expect(parentForm.get('resolutionY')!.value).toBe(2160);
+    });
+
+    it('should re-enable resolutionPreset when mode changes back to preset', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionMode')!.setValue('custom');
+      parentForm.get('resolutionMode')!.setValue('preset');
+      expect(parentForm.get('resolutionPreset')!.enabled).toBeTrue();
+    });
+
+    it('should remember the last-selected preset across a Custom round trip', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('uhd4k');
+      parentForm.get('resolutionMode')!.setValue('custom');
+      parentForm.get('resolutionX')!.setValue(2000);
+      parentForm.get('resolutionY')!.setValue(1500);
+      parentForm.get('resolutionMode')!.setValue('preset');
+      // The last-selected preset (uhd4k) is re-applied, NOT the default 1920x1080
+      expect(parentForm.get('resolutionX')!.value).toBe(3840);
+      expect(parentForm.get('resolutionY')!.value).toBe(2160);
+    });
+  });
+
+  describe('no spurious emissions during disable/enable round-trip (S5)', () => {
+    it('should not fire presetCtrl.valueChanges across a preset->custom->preset toggle', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      const presetCtrl = parentForm.get('resolutionPreset')!;
+      const spy = jasmine.createSpy('presetValueChangesSpy');
+      presetCtrl.valueChanges.subscribe(spy);
+      parentForm.get('resolutionMode')!.setValue('custom');
+      parentForm.get('resolutionMode')!.setValue('preset');
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('preset change while in custom mode is a no-op (S6)', () => {
+    it('should NOT modify parent X/Y when presetCtrl.setValue is called in custom mode', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionMode')!.setValue('custom');
+      parentForm.get('resolutionX')!.setValue(1600);
+      parentForm.get('resolutionY')!.setValue(900);
+      parentForm.get('resolutionPreset')!.setValue('uhd4k');
+      expect(parentForm.get('resolutionX')!.value).toBe(1600);
+      expect(parentForm.get('resolutionY')!.value).toBe(900);
+    });
+  });
+
+  describe('unknown preset id defensive guard (Q2)', () => {
+    it('should NOT modify parent X/Y when an unknown preset id is set in preset mode', async () => {
+      const parentForm = createParentForm();
+      await setup(parentForm);
+      parentForm.get('resolutionPreset')!.setValue('not-a-real-preset');
+      expect(parentForm.get('resolutionX')!.value).toBe(1920);
+      expect(parentForm.get('resolutionY')!.value).toBe(1080);
+    });
+  });
+
+  describe('auto-detect on load (brainstorm decision #1)', () => {
+    it('should land on preset mode with uhd4k when X/Y are pre-set to 3840/2160', async () => {
+      const parentForm = createParentForm({ resolutionX: 3840, resolutionY: 2160 });
+      await setup(parentForm);
+      expect(parentForm.get('resolutionMode')!.value).toBe('preset');
+      expect(parentForm.get('resolutionPreset')!.value).toBe('uhd4k');
+    });
+
+    it('should land on custom mode with X/Y enabled when X/Y are pre-set to 1600/900', async () => {
+      const parentForm = createParentForm({ resolutionX: 1600, resolutionY: 900 });
+      await setup(parentForm);
+      expect(parentForm.get('resolutionMode')!.value).toBe('custom');
+      expect(parentForm.get('resolutionX')!.enabled).toBeTrue();
+      expect(parentForm.get('resolutionY')!.enabled).toBeTrue();
+      expect(parentForm.get('resolutionPreset')!.value).toBe('fhd1080');
+    });
+  });
+
+  describe('null / zero edge cases (S9)', () => {
+    it('should not throw and default to custom/fhd1080 when X/Y are null', async () => {
+      const parentForm = createParentForm({ resolutionX: null, resolutionY: null });
+      let threw = false;
+      try {
+        await setup(parentForm);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBeFalse();
+      expect(parentForm.get('resolutionMode')!.value).toBe('custom');
+      expect(parentForm.get('resolutionPreset')!.value).toBe('fhd1080');
+    });
+
+    it('should not throw and default to custom/fhd1080 when X/Y are 0', async () => {
+      const parentForm = createParentForm({ resolutionX: 0, resolutionY: 0 });
+      let threw = false;
+      try {
+        await setup(parentForm);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBeFalse();
+      expect(parentForm.get('resolutionMode')!.value).toBe('custom');
+      expect(parentForm.get('resolutionPreset')!.value).toBe('fhd1080');
+    });
+  });
+
+  describe('template DOM assertions', () => {
+    it('should render the preset mat-select as disabled when mode is custom', async () => {
+      const parentForm = createParentForm();
+      const { fixture } = await setup(parentForm);
+      parentForm.get('resolutionMode')!.setValue('custom');
+      fixture.detectChanges();
+      const matSelect = fixture.nativeElement.querySelector('mat-select');
+      expect(matSelect).toBeTruthy();
+      const isDisabled = matSelect.classList.contains('mat-mdc-select-disabled')
+        || matSelect.classList.contains('mat-select-disabled')
+        || matSelect.getAttribute('aria-disabled') === 'true';
+      expect(isDisabled).toBeTrue();
+    });
+
+    it('should keep the mat-select element present in the DOM in both modes', async () => {
+      const parentForm = createParentForm();
+      const { fixture } = await setup(parentForm);
+      let matSelect = fixture.nativeElement.querySelector('mat-select');
+      expect(matSelect).toBeTruthy();
+      parentForm.get('resolutionMode')!.setValue('custom');
+      fixture.detectChanges();
+      matSelect = fixture.nativeElement.querySelector('mat-select');
+      expect(matSelect).toBeTruthy();
+      parentForm.get('resolutionMode')!.setValue('preset');
+      fixture.detectChanges();
+      matSelect = fixture.nativeElement.querySelector('mat-select');
+      expect(matSelect).toBeTruthy();
+    });
+  });
+});

--- a/manager/frontend/src/app/features/projects/resolution-input.component.ts
+++ b/manager/frontend/src/app/features/projects/resolution-input.component.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2025 Dryad and Naiad Software LLC
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatRadioModule } from '@angular/material/radio';
+import { Subscription } from 'rxjs';
+import {
+  RESOLUTION_PRESETS, ResolutionGroup, ResolutionPreset,
+  PRESET_GROUP_LABELS, findPresetByXY,
+} from './resolution-presets';
+
+@Component({
+  selector: 'app-resolution-input',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule, MatFormFieldModule, MatInputModule,
+    MatSelectModule, MatRadioModule,
+  ],
+  template: `
+    <div class="resolution-input">
+      <div class="resolution-header">
+        <label id="resolution-label" class="resolution-label">Render Resolution</label>
+        <mat-radio-group [formControl]="modeCtrl"
+                         aria-labelledby="resolution-label"
+                         class="resolution-mode">
+          <mat-radio-button value="preset">Use Preset</mat-radio-button>
+          <mat-radio-button value="custom">Custom</mat-radio-button>
+        </mat-radio-group>
+      </div>
+
+      <mat-form-field class="preset-select">
+        <mat-label>Preset</mat-label>
+        <mat-select [formControl]="presetCtrl">
+          @for (group of groupOrder; track group) {
+            <mat-optgroup [label]="groupLabels[group]">
+              @for (preset of presetsByGroup[group]; track preset.id) {
+                <mat-option [value]="preset.id">
+                  {{ preset.label }} — {{ preset.x }}×{{ preset.y }}
+                </mat-option>
+              }
+            </mat-optgroup>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <div class="resolution-xy">
+        <mat-form-field>
+          <mat-label>Resolution X</mat-label>
+          <input matInput type="number" [formControl]="resolutionXCtrl" />
+        </mat-form-field>
+        <mat-form-field>
+          <mat-label>Resolution Y</mat-label>
+          <input matInput type="number" [formControl]="resolutionYCtrl" />
+        </mat-form-field>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .resolution-input { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+    .resolution-header { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+    .resolution-label { font-weight: 500; }
+    .resolution-mode { display: flex; gap: 16px; }
+    .preset-select { width: 100%; }
+    .resolution-xy { display: flex; flex-direction: column; gap: 8px; }
+    .resolution-xy mat-form-field { width: 100%; }
+  `],
+})
+export class ResolutionInputComponent implements OnInit, OnDestroy {
+  @Input() parentForm!: FormGroup;
+
+  readonly groupOrder: ResolutionGroup[] = ['horizontal', 'cinema', 'vertical', 'square'];
+  readonly groupLabels = PRESET_GROUP_LABELS;
+  readonly presetsByGroup: Record<ResolutionGroup, ResolutionPreset[]> = {
+    horizontal: RESOLUTION_PRESETS.filter(p => p.group === 'horizontal'),
+    cinema:     RESOLUTION_PRESETS.filter(p => p.group === 'cinema'),
+    vertical:   RESOLUTION_PRESETS.filter(p => p.group === 'vertical'),
+    square:     RESOLUTION_PRESETS.filter(p => p.group === 'square'),
+  };
+
+  private subs: Subscription[] = [];
+
+  get modeCtrl() {
+    return this.parentForm.get('resolutionMode') as FormControl<'preset' | 'custom'>;
+  }
+  get presetCtrl() {
+    return this.parentForm.get('resolutionPreset') as FormControl<string>;
+  }
+  get resolutionXCtrl() {
+    return this.parentForm.get('resolutionX') as FormControl<number | null>;
+  }
+  get resolutionYCtrl() {
+    return this.parentForm.get('resolutionY') as FormControl<number | null>;
+  }
+
+  ngOnInit(): void {
+    const x = this.resolutionXCtrl.value;
+    const y = this.resolutionYCtrl.value;
+    const match = (typeof x === 'number' && typeof y === 'number')
+      ? findPresetByXY(x, y)
+      : null;
+
+    if (match) {
+      this.presetCtrl.setValue(match.id, { emitEvent: false });
+      this.modeCtrl.setValue('preset', { emitEvent: false });
+    } else {
+      this.modeCtrl.setValue('custom', { emitEvent: false });
+    }
+
+    this.updatePresetSelectDisabledState();
+    this.updateResolutionXYDisabledState();
+
+    this.subs.push(this.modeCtrl.valueChanges.subscribe(() => {
+      this.updatePresetSelectDisabledState();
+      this.updateResolutionXYDisabledState();
+      if (this.modeCtrl.value === 'preset') {
+        this.applySelectedPreset();
+      }
+    }));
+
+    this.subs.push(this.presetCtrl.valueChanges.subscribe(() => {
+      if (this.modeCtrl.value !== 'preset') return;
+      this.applySelectedPreset();
+    }));
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
+  }
+
+  private updatePresetSelectDisabledState(): void {
+    if (this.modeCtrl.value === 'custom') {
+      this.presetCtrl.disable({ emitEvent: false });
+    } else {
+      this.presetCtrl.enable({ emitEvent: false });
+    }
+  }
+
+  private updateResolutionXYDisabledState(): void {
+    if (this.modeCtrl.value === 'preset') {
+      this.resolutionXCtrl.disable({ emitEvent: false });
+      this.resolutionYCtrl.disable({ emitEvent: false });
+    } else {
+      this.resolutionXCtrl.enable({ emitEvent: false });
+      this.resolutionYCtrl.enable({ emitEvent: false });
+    }
+  }
+
+  private applySelectedPreset(): void {
+    const preset = RESOLUTION_PRESETS.find(p => p.id === this.presetCtrl.value);
+    if (!preset) return;
+    this.resolutionXCtrl.setValue(preset.x, { emitEvent: false });
+    this.resolutionYCtrl.setValue(preset.y, { emitEvent: false });
+  }
+}

--- a/manager/frontend/src/app/features/projects/resolution-presets.spec.ts
+++ b/manager/frontend/src/app/features/projects/resolution-presets.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 Dryad and Naiad Software LLC
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import {
+  RESOLUTION_PRESETS,
+  DEFAULT_PRESET_ID,
+  PRESET_GROUP_LABELS,
+  ResolutionGroup,
+  findPresetByXY,
+} from './resolution-presets';
+
+describe('resolution-presets', () => {
+  describe('RESOLUTION_PRESETS catalog', () => {
+    it('should contain exactly 13 entries', () => {
+      expect(RESOLUTION_PRESETS.length).toBe(13);
+    });
+
+    it('should appear in the group order horizontal, cinema, vertical, square (no interleaving)', () => {
+      const expectedOrder: ResolutionGroup[] = ['horizontal', 'cinema', 'vertical', 'square'];
+      let currentExpectedIndex = 0;
+      for (const preset of RESOLUTION_PRESETS) {
+        const groupIndex = expectedOrder.indexOf(preset.group);
+        expect(groupIndex).toBeGreaterThanOrEqual(currentExpectedIndex);
+        currentExpectedIndex = groupIndex;
+      }
+    });
+
+    it('should have every preset id be unique', () => {
+      const ids = RESOLUTION_PRESETS.map(p => p.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+  });
+
+  describe('DEFAULT_PRESET_ID', () => {
+    it('should equal "fhd1080"', () => {
+      expect(DEFAULT_PRESET_ID).toBe('fhd1080');
+    });
+
+    it('should refer to a preset whose x is 1920 and y is 1080', () => {
+      const defaultPreset = RESOLUTION_PRESETS.find(p => p.id === DEFAULT_PRESET_ID);
+      expect(defaultPreset).toBeDefined();
+      expect(defaultPreset!.x).toBe(1920);
+      expect(defaultPreset!.y).toBe(1080);
+    });
+  });
+
+  describe('findPresetByXY', () => {
+    it('should return the fhd1080 preset object for 1920x1080', () => {
+      const expected = RESOLUTION_PRESETS.find(p => p.id === 'fhd1080');
+      expect(findPresetByXY(1920, 1080)).toEqual(expected!);
+    });
+
+    it('should return the uhd4k preset object for 3840x2160', () => {
+      const expected = RESOLUTION_PRESETS.find(p => p.id === 'uhd4k');
+      expect(findPresetByXY(3840, 2160)).toEqual(expected!);
+    });
+
+    it('should return null for 1600x900 (no matching preset)', () => {
+      expect(findPresetByXY(1600, 900)).toBeNull();
+    });
+
+    it('should return the uhd8k preset object for 7680x4320 (edge of range)', () => {
+      const expected = RESOLUTION_PRESETS.find(p => p.id === 'uhd8k');
+      expect(findPresetByXY(7680, 4320)).toEqual(expected!);
+    });
+  });
+
+  describe('PRESET_GROUP_LABELS', () => {
+    it('should label horizontal as "Horizontal (16:9)"', () => {
+      expect(PRESET_GROUP_LABELS.horizontal).toBe('Horizontal (16:9)');
+    });
+
+    it('should label cinema as "Cinema (DCI)"', () => {
+      expect(PRESET_GROUP_LABELS.cinema).toBe('Cinema (DCI)');
+    });
+
+    it('should label vertical as "Vertical (9:16)"', () => {
+      expect(PRESET_GROUP_LABELS.vertical).toBe('Vertical (9:16)');
+    });
+
+    it('should label square as "Square (1:1)"', () => {
+      expect(PRESET_GROUP_LABELS.square).toBe('Square (1:1)');
+    });
+  });
+});

--- a/manager/frontend/src/app/features/projects/resolution-presets.ts
+++ b/manager/frontend/src/app/features/projects/resolution-presets.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Dryad and Naiad Software LLC
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+export type ResolutionGroup = 'horizontal' | 'cinema' | 'vertical' | 'square';
+
+export interface ResolutionPreset {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  group: ResolutionGroup;
+}
+
+export const RESOLUTION_PRESETS: ResolutionPreset[] = [
+  // Horizontal (16:9)
+  { id: 'hd720',        label: '720p',              x: 1280, y: 720,  group: 'horizontal' },
+  { id: 'fhd1080',      label: '1080p',             x: 1920, y: 1080, group: 'horizontal' },
+  { id: 'qhd1440',      label: '1440p (2K QHD)',    x: 2560, y: 1440, group: 'horizontal' },
+  { id: 'uhd4k',        label: '4K UHD',            x: 3840, y: 2160, group: 'horizontal' },
+  { id: 'uhd8k',        label: '8K UHD',            x: 7680, y: 4320, group: 'horizontal' },
+  // Cinema (DCI)
+  { id: 'dci2k',        label: 'DCI 2K',            x: 2048, y: 1080, group: 'cinema'     },
+  { id: 'dci4k',        label: 'DCI 4K',            x: 4096, y: 2160, group: 'cinema'     },
+  // Vertical (9:16)
+  { id: 'hd720v',       label: '720p Vertical',     x: 720,  y: 1280, group: 'vertical'   },
+  { id: 'fhd1080v',     label: '1080p Vertical',    x: 1080, y: 1920, group: 'vertical'   },
+  { id: 'qhd1440v',     label: '1440p Vertical',    x: 1440, y: 2560, group: 'vertical'   },
+  { id: 'uhd4kv',       label: '4K Vertical',       x: 2160, y: 3840, group: 'vertical'   },
+  // Square (1:1)
+  { id: 'sq1080',       label: '1080 Square',       x: 1080, y: 1080, group: 'square'     },
+  { id: 'sq2160',       label: '2160 Square',       x: 2160, y: 2160, group: 'square'     },
+];
+
+export const DEFAULT_PRESET_ID = 'fhd1080';
+
+export const PRESET_GROUP_LABELS: Record<ResolutionGroup, string> = {
+  horizontal: 'Horizontal (16:9)',
+  cinema:     'Cinema (DCI)',
+  vertical:   'Vertical (9:16)',
+  square:     'Square (1:1)',
+};
+
+export function findPresetByXY(x: number, y: number): ResolutionPreset | null {
+  return RESOLUTION_PRESETS.find(p => p.x === x && p.y === y) ?? null;
+}


### PR DESCRIPTION
## Summary

Replaces the bare Resolution X / Y inputs on the job-create form with a two-mode picker: a curated dropdown of 13 common resolutions plus a Custom mode that retains arbitrary entry. Frontend-only — zero backend, API, or model changes.

## What's new

- **Radio-driven mode toggle**: Use Preset (default) or Custom
- **13 presets in 4 grouped categories** (mat-optgroup), in display order:
  - **Horizontal (16:9)**: 720p, **1080p (default)**, 1440p (2K QHD), 4K UHD, 8K UHD
  - **Cinema (DCI)**: DCI 2K, DCI 4K
  - **Vertical (9:16)**: 720p, 1080p, 1440p, 4K
  - **Square (1:1)**: 1080, 2160
- **Auto-detect on load**: if a prefilled X/Y matches a preset, the form opens in Preset mode with that preset selected; otherwise Custom mode
- **Last-selected preset preserved** across Custom round-trips: if the user picks 4K UHD, switches to Custom and types 1600×900, then switches back to Preset, X/Y snap to 3840×2160 (not the default 1080p)
- **Custom mode keeps the dropdown visible but disabled** to prevent layout shift between modes

## Technical approach

- New constants module `resolution-presets.ts` exports the 13-preset catalog, `ResolutionPreset` interface, `DEFAULT_PRESET_ID`, group labels, and a `findPresetByXY` exact-match helper
- New child component `resolution-input.component.ts` follows the established `video-output-section.component.ts` pattern: parent declares all FormControls, child takes `@Input parentForm`, exposes typed getters, binds with `[formControl]` (no `[formGroup]` wrapper, no `formControlName`), uses imperative `.disable()/.enable({ emitEvent: false })` and a manual `Subscription[]` aggregator
- Parent `job-create-form.component.ts` adds two new controls (`resolutionMode`, `resolutionPreset`) to its existing form literal, drops the inline X/Y `<mat-form-field>` blocks and the `.res-x` separator, and renders `<app-resolution-input [parentForm]="form" />` in their place
- Net delta: parent goes from 250 → 248 lines (under the 250-line TypeScript file size limit)
- `onSubmit()`, `buildSingleJobPayload`, `buildTiledJobPayload`, `buildAnimationPayload`, `render-payload.util.ts`, `job-create-payload.util.ts`, and the entire backend are completely unchanged. `form.getRawValue()` reads through disabled controls, so the submitted payload still includes `render.resolution_x` / `render.resolution_y` byte-identical to before

## Process

This change went through the full multiagent pipeline: brainstorming → spec v1 (docs-agent) → spec review (frontend-reviewer flagged C1/C2/C3 for pattern alignment) → spec v2 → frontend-dev implementation → frontend-unit-test → frontend-integration-test (no new tests needed: zero API surface change, no Playwright in repo) → frontend code review (APPROVE) → final gatekeeper (APPROVED FOR MERGE, 7/7 gates, 76/76 compliance) → manual QA in the live dialog.

## Test plan

- [x] Frontend unit tests: 36 new tests, 213/213 passing (was 177)
- [x] Backend regression tests: 968/968 passing
- [x] Manual QA against running manager + Angular UI:
  - [x] Dialog default state: Preset mode, 1080p selected, X=1920/Y=1080 disabled
  - [x] All 4 optgroups in order Horizontal → Cinema → Vertical → Square
  - [x] All 13 presets present with correct pixel dimensions
  - [x] Selecting 4K UHD writes 3840/2160 into X/Y
  - [x] Switching to Custom mode enables X/Y, disables dropdown (still visible — no layout shift)
  - [x] Typing custom 1600×900 then switching back to Preset re-applies 4K UHD (3840×2160), NOT the default — brainstorm decision #2 regression guard
  - [x] No Angular `[disabled]`-with-reactive-form warnings in the console (verifies the imperative disable pattern from C2)
  - [x] End-to-end submission: created a real job via the UI in Preset mode and verified the API received `render.resolution_x: 3840` / `render.resolution_y: 2160` byte-identical to the legacy payload shape

## Files changed

| File | Status | Lines |
|---|---|---|
| `manager/frontend/src/app/features/projects/resolution-presets.ts` | NEW | 46 |
| `manager/frontend/src/app/features/projects/resolution-input.component.ts` | NEW | 159 |
| `manager/frontend/src/app/features/projects/resolution-presets.spec.ts` | NEW | 87 |
| `manager/frontend/src/app/features/projects/resolution-input.component.spec.ts` | NEW | 247 |
| `manager/frontend/src/app/features/projects/job-create-form.component.resolution.spec.ts` | NEW | 130 |
| `manager/frontend/src/app/features/projects/job-create-form.component.ts` | MODIFIED | 250 → 248 |